### PR TITLE
Bugfix/bulk update id columns

### DIFF
--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase.csproj
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase.csproj
@@ -16,8 +16,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Scripts\" />
-  </ItemGroup>
-
 </Project>

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/FamilyHome.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/FamilyHome.cs
@@ -1,0 +1,14 @@
+﻿using CSESoftware.Core.Entity;
+using System;
+using System.Collections.Generic;
+
+namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase
+{
+    public class FamilyHome : BaseEntity<Guid>
+    {
+        public string Name { get; set; }
+        public string Address { get; set; }
+
+        public virtual ICollection<FamilyTree> Families { get; set; }
+    }
+}

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/FamilyTree.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/FamilyTree.cs
@@ -16,6 +16,9 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase
         public Guid MotherId { get; set; }
         public virtual FamilyTree Mother { get; set; }
 
+        public Guid HomeId { get; set; }
+        public virtual FamilyHome Home { get; set; }
+
         public virtual ICollection<FamilyTreeLink> Siblings { get; set; }
         public virtual ICollection<FamilyTreeLink> CounterSiblings { get; set; }
 

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Migrations/20220407204007_ColumnNameMismatch.Designer.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Migrations/20220407204007_ColumnNameMismatch.Designer.cs
@@ -4,14 +4,16 @@ using CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase.Migrations
 {
     [DbContext(typeof(TestContext))]
-    partial class TestContextModelSnapshot : ModelSnapshot
+    [Migration("20220407204007_ColumnNameMismatch")]
+    partial class ColumnNameMismatch
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Migrations/20220407204007_ColumnNameMismatch.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Migrations/20220407204007_ColumnNameMismatch.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase.Migrations
+{
+    public partial class ColumnNameMismatch : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "HomeId",
+                table: "FamilyTrees",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "Home_Alpha",
+                columns: table => new
+                {
+                    HomeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Home_Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Home_Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Home_Alpha", x => x.HomeId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FamilyTrees_HomeId",
+                table: "FamilyTrees",
+                column: "HomeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FamilyTrees_Home_Alpha_HomeId",
+                table: "FamilyTrees",
+                column: "HomeId",
+                principalTable: "Home_Alpha",
+                principalColumn: "HomeId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FamilyTrees_Home_Alpha_HomeId",
+                table: "FamilyTrees");
+
+            migrationBuilder.DropTable(
+                name: "Home_Alpha");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FamilyTrees_HomeId",
+                table: "FamilyTrees");
+
+            migrationBuilder.DropColumn(
+                name: "HomeId",
+                table: "FamilyTrees");
+        }
+    }
+}

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Scripts/ColumnNameMismatch Migration.sql
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/Scripts/ColumnNameMismatch Migration.sql
@@ -1,0 +1,29 @@
+﻿BEGIN TRANSACTION;
+GO
+
+ALTER TABLE [FamilyTrees] ADD [HomeId] uniqueidentifier NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+GO
+
+CREATE TABLE [Home_Alpha] (
+    [HomeId] uniqueidentifier NOT NULL,
+    [Home_Name] nvarchar(max) NULL,
+    [Home_Address] nvarchar(max) NULL,
+    [IsActive] bit NOT NULL,
+    [CreatedDate] datetime2 NOT NULL,
+    [ModifiedDate] datetime2 NOT NULL,
+    CONSTRAINT [PK_Home_Alpha] PRIMARY KEY ([HomeId])
+);
+GO
+
+CREATE INDEX [IX_FamilyTrees_HomeId] ON [FamilyTrees] ([HomeId]);
+GO
+
+ALTER TABLE [FamilyTrees] ADD CONSTRAINT [FK_FamilyTrees_Home_Alpha_HomeId] FOREIGN KEY ([HomeId]) REFERENCES [Home_Alpha] ([HomeId]) ON DELETE NO ACTION;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20220407204007_ColumnNameMismatch', N'5.0.10');
+GO
+
+COMMIT;
+GO

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/TestContext.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase/TestContext.cs
@@ -11,6 +11,7 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase
         }
 
         public DbSet<FamilyTree> FamilyTrees { get; set; }
+        public DbSet<FamilyHome> FamilyHomes { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -24,6 +25,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase
                 .WithMany(p => p.MaternalChildren)
                 .HasForeignKey(pp => pp.MotherId);
 
+            modelBuilder.Entity<FamilyTree>()
+                .HasOne(pp => pp.Home)
+                .WithMany(p => p.Families)
+                .HasForeignKey(pp => pp.HomeId);
+
             modelBuilder.Entity<FamilyTreeLink>()
                 .HasKey(x => new { x.PrimarySiblingId, x.SecondarySiblingId });
 
@@ -36,6 +42,15 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestDatabase
                 .HasOne(pp => pp.SecondarySibling)
                 .WithMany(p => p.Siblings)
                 .HasForeignKey(pp => pp.SecondarySiblingId);
+
+            modelBuilder.Entity<FamilyHome>()
+                .ToTable("Home_Alpha");
+            modelBuilder.Entity<FamilyHome>()
+                .Property(x => x.Id).HasColumnName("HomeId");
+            modelBuilder.Entity<FamilyHome>()
+                .Property(x => x.Name).HasColumnName("Home_Name");
+            modelBuilder.Entity<FamilyHome>()
+                .Property(x => x.Address).HasColumnName("Home_Address");
 
             var cascadeFKs = modelBuilder.Model.GetEntityTypes()
                 .SelectMany(t => t.GetForeignKeys())

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/SelectTests.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/SelectTests.cs
@@ -86,6 +86,51 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
             await TearDownAsync(trees, links);
         }
 
+        [Fact]
+        public async Task SelectMismatchedColumnTest()
+        {
+            var homes = await HomeStartUpAsync();
+            var selectValues = homes.Select(x => new { x.Id, x.Name }).ToList();
+            var returnValues = await Repository.BulkSelectAsync(new FamilyHome(), selectValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var value in returnValues)
+                Assert.Contains(value.Id, homes.Select(x => x.Id));
+
+            await TearDownAsync(homes);
+        }
+
+        [Fact]
+        public async Task SelectMismatchedColumnTest_WithIdColumnName()
+        {
+            var homes = await HomeStartUpAsync();
+            var selectValues = homes.Select(x => new { HomeId = x.Id, x.Address }).ToList();
+            var returnValues = await Repository.BulkSelectAsync(new FamilyHome(), selectValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var value in returnValues)
+                Assert.Contains(value.Id, homes.Select(x => x.Id));
+
+            await TearDownAsync(homes);
+        }
+
+        [Fact]
+        public async Task SelectMismatchedColumnTest_WithSelectColumnName()
+        {
+            var homes = await HomeStartUpAsync();
+            var selectValues = homes.Select(x => new { x.Id, Home_Name = x.Name }).ToList();
+            var returnValues = await Repository.BulkSelectAsync(new FamilyHome(), selectValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var value in returnValues)
+                Assert.Contains(value.Id, homes.Select(x => x.Id));
+
+            await TearDownAsync(homes);
+        }
+
         private async Task<List<FamilyTree>> StartUpAsync(int numberOfTrees = 100,
             string gender = "Tomato", bool isAlive = true)
         {
@@ -104,6 +149,14 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
             await Repository.BulkCreateAsync(links);
 
             return (trees, links);
+        }
+
+        private async Task<List<FamilyHome>> HomeStartUpAsync()
+        {
+            var homes = DataProvider.GetSimpleHomes(100);
+            await Repository.BulkCreateAsync(homes);
+
+            return homes;
         }
 
         private static IQuery<FamilyTree> GetTreeQuery()

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/Setup/BaseTest.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/Setup/BaseTest.cs
@@ -27,6 +27,14 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject.Setup
                 await Repository.BulkDeleteAsync(new FamilyTree(), treesToDelete);
         }
 
+        internal async Task TearDownAsync(IEnumerable<FamilyHome> homes)
+        {
+            var homesToDelete = homes.Select(x => new { x.Id }).ToList();
+            
+            if (homesToDelete.Any())
+                await Repository.BulkDeleteAsync(new FamilyHome(), homesToDelete);
+        }
+
         internal static List<FamilyTreeLink> GetDistinctLinks(IReadOnlyCollection<FamilyTree> trees)
         {
             return trees.Where(x => x.Siblings != null).SelectMany(x => x.Siblings)

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/Setup/DataProvider.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/Setup/DataProvider.cs
@@ -43,6 +43,16 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject.Setup
             return trees;
         }
 
+        internal static List<FamilyHome> GetSimpleHomes(int numberOfHomes = 10, string name = "Our House",
+            string address = "555 Quantum Place")
+        {
+            var homes = new List<FamilyHome>();
+            for (var i = 0; i < numberOfHomes; i++)
+                homes.Add(GetHome($"{name} {i}", $"{address} Apt #{i}"));
+
+            return homes;
+        }
+
         private static FamilyTree GetTree(DateTime birthdate, string gender = "Tomato", bool isAlive = true)
         {
             return new FamilyTree
@@ -85,6 +95,20 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject.Setup
             }).ToList();
 
             return tree;
+        }
+
+        private static FamilyHome GetHome(string name, string address)
+        {
+            return new FamilyHome
+            {
+                Id = Guid.NewGuid(),
+                IsActive = true,
+                CreatedDate = DateTime.Now,
+                ModifiedDate = DateTime.Now,
+                Name = name,
+                Address = address,
+                Families = new List<FamilyTree>()
+            };
         }
     }
 }

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/UpdateTests.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore.TestProject/UpdateTests.cs
@@ -14,11 +14,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
         public async Task UpdateGenderTest()
         {
             const string gender = "Passion Fruit";
-            var trees = await StartUpAsync();
+            var trees = await TreeStartUpAsync();
             var operationValues = trees.Select(x => new { x.Id, Gender = gender }).ToList();
             
             await Repository.BulkUpdateAsync(new FamilyTree(), operationValues);
-            var returnValues = await GetUpdatedValuesAsync(operationValues);
+            var returnValues = await GetUpdatedTreeValuesAsync(operationValues);
 
             Assert.NotNull(returnValues);
             Assert.NotEmpty(returnValues);
@@ -34,11 +34,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
         [Fact]
         public async Task UpdateIsAliveTest()
         {
-            var trees = await StartUpAsync();
+            var trees = await TreeStartUpAsync();
             var operationValues = trees.Select(x => new { x.Id, IsAlive = false }).ToList();
 
             await Repository.BulkUpdateAsync(new FamilyTree(), operationValues);
-            var returnValues = await GetUpdatedValuesAsync(operationValues);
+            var returnValues = await GetUpdatedTreeValuesAsync(operationValues);
 
             Assert.NotNull(returnValues);
             Assert.NotEmpty(returnValues);
@@ -55,11 +55,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
         public async Task UpdateBirthdateTest()
         {
             var birthdate = DateTime.UtcNow - TimeSpan.FromDays(4721);
-            var trees = await StartUpAsync();
+            var trees = await TreeStartUpAsync();
             var operationValues = trees.Select(x => new { x.Id, Birthdate = birthdate }).ToList();
 
             await Repository.BulkUpdateAsync(new FamilyTree(), operationValues);
-            var returnValues = await GetUpdatedValuesAsync(operationValues);
+            var returnValues = await GetUpdatedTreeValuesAsync(operationValues);
 
             Assert.NotNull(returnValues);
             Assert.NotEmpty(returnValues);
@@ -77,11 +77,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
         {
             var fatherId = Guid.NewGuid();
             var father = new FamilyTree { Id = fatherId };
-            var trees = await StartUpAsync(father);
+            var trees = await TreeStartUpAsync(father);
             var operationValues = trees.Select(x => new { x.Id, FatherId = fatherId }).ToList();
 
             await Repository.BulkUpdateAsync(new FamilyTree(), operationValues);
-            var returnValues = await GetUpdatedValuesAsync(operationValues);
+            var returnValues = await GetUpdatedTreeValuesAsync(operationValues);
 
             Assert.NotNull(returnValues);
             Assert.NotEmpty(returnValues);
@@ -94,7 +94,70 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
             await TearDownAsync(trees);
         }
 
-        private async Task<List<FamilyTree>> StartUpAsync(FamilyTree father = null)
+        [Fact]
+        public async Task UpdateMismatchedColumnTest()
+        {
+            const string name = "Bob's Home";
+            var homes = await HomeStartUpAsync();
+            var operationValues = homes.Select(x => new { x.Id, Name = name }).ToList();
+
+            await Repository.BulkUpdateAsync(new FamilyHome(), operationValues);
+            var returnValues = await GetUpdatedHomeValuesAsync(operationValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var home in homes)
+            {
+                Assert.True(returnValues.ContainsKey(home.Id));
+                Assert.Contains(name, returnValues[home.Id].Name);
+            }
+
+            await TearDownAsync(homes);
+        }
+
+        [Fact]
+        public async Task UpdateMismatchedColumnTest_WithIdColumnName()
+        {
+            const string address = "1918 Burbank";
+            var homes = await HomeStartUpAsync();
+            var operationValues = homes.Select(x => new { HomeId = x.Id, Address = address }).ToList();
+
+            await Repository.BulkUpdateAsync(new FamilyHome(), operationValues);
+            var returnValues = await GetUpdatedHomeValuesAsync(operationValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var home in homes)
+            {
+                Assert.True(returnValues.ContainsKey(home.Id));
+                Assert.Contains(address, returnValues[home.Id].Address);
+            }
+
+            await TearDownAsync(homes);
+        }
+
+        [Fact]
+        public async Task UpdateMismatchedColumnTest_WithUpdateColumnName()
+        {
+            const string address = "1918 Burbank";
+            var homes = await HomeStartUpAsync();
+            var operationValues = homes.Select(x => new { HomeId = x.Id, Home_Address = address }).ToList();
+
+            await Repository.BulkUpdateAsync(new FamilyHome(), operationValues);
+            var returnValues = await GetUpdatedHomeValuesAsync(operationValues);
+
+            Assert.NotNull(returnValues);
+            Assert.NotEmpty(returnValues);
+            foreach (var home in homes)
+            {
+                Assert.True(returnValues.ContainsKey(home.Id));
+                Assert.Contains(address, returnValues[home.Id].Address);
+            }
+
+            await TearDownAsync(homes);
+        }
+
+        private async Task<List<FamilyTree>> TreeStartUpAsync(FamilyTree father = null)
         {
             var trees = DataProvider.GetSimpleTrees(100);
             if (father != null) trees.Add(father);
@@ -103,10 +166,25 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.TestProject
             return trees;
         }
 
-        private async Task<Dictionary<Guid, FamilyTree>> GetUpdatedValuesAsync<TObject>(
+        private async Task<Dictionary<Guid, FamilyTree>> GetUpdatedTreeValuesAsync<TObject>(
             IReadOnlyCollection<TObject> operationValues)
         {
             var returnValues = await Repository.BulkSelectAsync(new FamilyTree(), operationValues);
+            return returnValues.ToDictionary(x => x.Id, x => x);
+        }
+
+        private async Task<List<FamilyHome>> HomeStartUpAsync()
+        {
+            var homes = DataProvider.GetSimpleHomes(100);
+            await Repository.BulkCreateAsync(homes);
+
+            return homes;
+        }
+
+        private async Task<Dictionary<Guid, FamilyHome>> GetUpdatedHomeValuesAsync<TObject>(
+            IReadOnlyCollection<TObject> operationValues)
+        {
+            var returnValues = await Repository.BulkSelectAsync(new FamilyHome(), operationValues);
             return returnValues.ToDictionary(x => x.Id, x => x);
         }
     }

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/BulkRepository.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/BulkRepository.cs
@@ -236,7 +236,9 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore
 
                     var parameters =
                         RepositoryHelper.AssembleParameters(Context, entityToUpdate, updateByValues.ElementAt(0), type);
-                    ExecuteUpdateQuery<TEntity>(command, parameters);
+                    var keyString =
+                        RepositoryHelper.GetUpdateKeyString(Context, entityToUpdate, updateByValues.ElementAt(0));
+                    ExecuteUpdateQuery<TEntity>(command, parameters, keyString);
                     success = true;
                 }
                 catch (SqlException ex)
@@ -314,13 +316,13 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore
             return Context.Set<TEntity>().FromSqlRaw(queryString);
         }
 
-        private void ExecuteUpdateQuery<TEntity>(IDbCommand command, string parameters)
+        private void ExecuteUpdateQuery<TEntity>(IDbCommand command, string parameters, string keyString)
             where TEntity : IEntity
         {
             var destinationTableName = Context.GetTableName<TEntity>();
 
             command.CommandText =
-                $"UPDATE O SET {parameters} FROM {destinationTableName} O INNER JOIN {ConstUpdateTableName} T ON O.Id = T.Id";
+                $"UPDATE O SET {parameters} FROM {destinationTableName} O INNER JOIN {ConstUpdateTableName} T ON {keyString}";
             command.ExecuteNonQuery();
         }
 

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Authors>CSESoftware, Inc.</Authors>
     <Company>CSESoftware, Inc.</Company>
-    <Version>1.0.1-beta2</Version>
+    <Version>1.0.1</Version>
     <Description>An Entity Framework Core repository utilizing SqlBulkCopy to perform operations on large datasets.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>2022 CSE Software, Inc.</Copyright>

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Authors>CSESoftware, Inc.</Authors>
     <Company>CSESoftware, Inc.</Company>
-    <Version>1.0.0</Version>
+    <Version>1.0.1-beta1</Version>
     <Description>An Entity Framework Core repository utilizing SqlBulkCopy to perform operations on large datasets.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>2022 CSE Software, Inc.</Copyright>

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/CSESoftware.Repository.SqlBulkRepositoryCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Authors>CSESoftware, Inc.</Authors>
     <Company>CSESoftware, Inc.</Company>
-    <Version>1.0.1-beta1</Version>
+    <Version>1.0.1-beta2</Version>
     <Description>An Entity Framework Core repository utilizing SqlBulkCopy to perform operations on large datasets.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>2022 CSE Software, Inc.</Copyright>

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/RepositoryHelpers/RepositoryHelper.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/RepositoryHelpers/RepositoryHelper.cs
@@ -15,7 +15,7 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.RepositoryHelpers
         /// operational data tables in the database.
         /// </summary>
         /// <typeparam name="TEntity">An entity that exists in the database</typeparam>
-        /// <typeparam name="TObject">An anonymous object with properties that match column names for the database object</typeparam>
+        /// <typeparam name="TObject">An anonymous object with properties that match column names or property names for the database object</typeparam>
         /// <param name="context">Database context necessary for column mapping</param>
         /// <param name="entity">A sample of the entity to be used for processing</param>
         /// <param name="operationObject">A sample of the anonymous object to be matched to the entity</param>
@@ -25,7 +25,9 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.RepositoryHelpers
             TObject operationObject, OperationType type)
             where TEntity : IEntity
         {
-            var entityProperties = GetPropertyNames(entity);
+            if (entity == null) return string.Empty;
+
+            var entityProperties = RetrieveEntityColumnNames<TEntity>(context);
             var operationEntityProperties = GetPropertyNames(operationObject);
 
             return type == OperationType.Update
@@ -106,6 +108,36 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.RepositoryHelpers
         }
 
         /// <summary>
+        /// This function provides a one or many key equality match for update query strings, where the property match in the
+        /// update generic object may match the database column name or clr type property name. If the table has a composite key,
+        /// string enforces a match on all relevant primary keys.
+        /// </summary>
+        /// <typeparam name="TEntity">An entity that exists in the database</typeparam>
+        /// <typeparam name="TObject">An anonymous object with properties that match column names or property names for the database object</typeparam>
+        /// <param name="context">The database context to query</param>
+        /// <param name="entity">A sample of the entity to be used for processing</param>
+        /// <param name="operationObject">A sample of the anonymous object to be matched to the entity</param>
+        /// <returns></returns>
+        internal static string GetUpdateKeyString<TEntity, TObject>(DbContext context, TEntity entity,
+            TObject operationObject)
+            where TEntity : IEntity
+        {
+            if (entity == null) return string.Empty;
+
+            var operationObjectProperties = GetPropertyNames(operationObject);
+            var entityProperties = RetrieveEntityColumnNames<TEntity>(context);
+            var primaryKeyColumns = GetPrimaryKeyNames<TEntity>(context);
+            var primaryKeyProperties = entityProperties.Where(x => primaryKeyColumns.Contains(x.Key))
+                .ToDictionary(x => x.Key, x => x.Value);
+
+            var returnList = operationObjectProperties.Where(x =>
+                    primaryKeyProperties.ContainsKey(x) || primaryKeyProperties.Values.Contains(x))
+                .Select(prop => ConstructMatchString(prop, entityProperties)).ToList();
+
+            return returnList.Count > 1 ? string.Join(" AND ", returnList) : returnList[0];
+        }
+
+        /// <summary>
         /// This function takes in a date and rounds it down to the preceding second. This is to counter DateTime comparison difficulties
         /// between CLR DateTime objects and SQL DateTime column data.
         /// </summary>
@@ -124,33 +156,45 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.RepositoryHelpers
         }
 
         private static string AssembleUpdateColumnToColumnMatch<TEntity>(DbContext context,
-            ICollection<string> entityProperties, IEnumerable<string> updateProperties)
+            IReadOnlyDictionary<string, string> entityProperties, IEnumerable<string> updateProperties)
             where TEntity : IEntity
         {
-            var primaryKeys = context.Model.GetEntityTypes(typeof(TEntity))
-                .Select(x => x.FindPrimaryKey());
-            var primaryKeyColumns = primaryKeys.SelectMany(x => x.Properties)
-                .Select(x => x.Name).ToList();
+            var primaryKeyColumns = GetPrimaryKeyNames<TEntity>(context);
 
             var returnList = updateProperties.Where(x =>
-                    entityProperties.Contains(x) && !primaryKeyColumns.Contains(x))
+                    !primaryKeyColumns.Contains(x) &&
+                    (entityProperties.ContainsKey(x) || entityProperties.Values.Contains(x)))
                 .Select(prop => ConstructMatchString(prop, entityProperties)).ToList();
 
             return string.Join(",", returnList);
         }
 
-        private static string AssembleSelectColumnToColumnMatch(ICollection<string> entityProperties,
+        private static string AssembleSelectColumnToColumnMatch(IReadOnlyDictionary<string, string> entityProperties,
             IEnumerable<string> selectProperties)
         {
-            var returnList = selectProperties.Where(entityProperties.Contains)
+            var returnList = selectProperties
+                .Where(x => entityProperties.Values.Contains(x) || entityProperties.ContainsKey(x))
                 .Select(prop => ConstructMatchString(prop, entityProperties)).ToList();
 
             return returnList.Count > 1 ? string.Join(" AND ", returnList) : returnList[0];
         }
 
-        private static string ConstructMatchString(string property, IEnumerable<string> possibleMatches)
+        private static List<string> GetPrimaryKeyNames<TEntity>(DbContext context)
+            where TEntity : IEntity
         {
-            var match = possibleMatches.First(x => x == property);
+            var primaryKeys = context.Model.GetEntityTypes(typeof(TEntity))
+                .Select(x => x.FindPrimaryKey());
+            return primaryKeys.SelectMany(x => x.Properties)
+                .Select(x => x.GetColumnName(StoreObjectIdentifier.Table(GetTableName<TEntity>(context), null)))
+                .ToList();
+        }
+
+        private static string ConstructMatchString(string property, IReadOnlyDictionary<string, string> possibleMatches)
+        {
+            var match = possibleMatches.ContainsKey(property)
+                ? possibleMatches.Keys.First(x => x == property)
+                : possibleMatches.First(x => x.Value == property).Key;
+
             return $"O.{match} = T.{property}";
         }
 

--- a/src/CSESoftware.Repository.SqlBulkRepositoryCore/RepositoryHelpers/RepositoryHelper.cs
+++ b/src/CSESoftware.Repository.SqlBulkRepositoryCore/RepositoryHelpers/RepositoryHelper.cs
@@ -160,9 +160,11 @@ namespace CSESoftware.Repository.SqlBulkRepositoryCore.RepositoryHelpers
             where TEntity : IEntity
         {
             var primaryKeyColumns = GetPrimaryKeyNames<TEntity>(context);
+            var primaryKeyProperties = entityProperties.Where(x => primaryKeyColumns.Contains(x.Key))
+                .ToDictionary(x => x.Key, x => x.Value);
 
             var returnList = updateProperties.Where(x =>
-                    !primaryKeyColumns.Contains(x) &&
+                    !primaryKeyProperties.ContainsKey(x) && !primaryKeyProperties.Values.Contains(x) &&
                     (entityProperties.ContainsKey(x) || entityProperties.Values.Contains(x)))
                 .Select(prop => ConstructMatchString(prop, entityProperties)).ToList();
 


### PR DESCRIPTION
- Code changes to support table column names mismatched with clr property names on Bulk Select and Bulk Update
- Test Database context changes to support mismatched property and column names
- Unit Tests adjusted to validate Update and Select with mismatched column and property names
- Correction for problem with update columns when auto-incrementing and mismatched with property name